### PR TITLE
Add fontconfig and ttf-dejavu packages to allow running GUI-mode/x11 forwarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV PATH ${JMETER_BIN}:$PATH
 COPY entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh \
  && apk add --no-cache \
+    fontconfig ttf-dejavu \
     curl \
     net-tools \
     shadow \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ STOPSIGNAL SIGKILL
 ENV JMETER_VERSION 5.1.1
 ENV JMETER_HOME /opt/apache-jmeter-${JMETER_VERSION}
 ENV JMETER_BIN ${JMETER_HOME}/bin
+ENV ALPN_VERSION 8.1.13.v20181017
 ENV PATH ${JMETER_BIN}:$PATH
 COPY entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh \
@@ -25,7 +26,12 @@ RUN chmod +x /usr/local/bin/entrypoint.sh \
  && sed -i '/PrintGCDetails/s/^# /: "${/g' ${JMETER_BIN}/jmeter && sed -i '/PrintGCDetails/s/$/}"/g' ${JMETER_BIN}/jmeter \
  && chmod +x ${JMETER_HOME}/bin/*.sh \
  && jmeter --version \
+ && curl --location --silent --show-error --output /opt/alpn-boot-${ALPN_VERSION}.jar http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/${ALPN_VERSION}/alpn-boot-${ALPN_VERSION}.jar \
  && rm -fr /tmp/*
+
+# Required for HTTP2 plugins
+ENV JVM_ARGS -Xbootclasspath/p:/opt/alpn-boot-${ALPN_VERSION}.jar
+
 WORKDIR /jmeter
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["jmeter", "--?"]


### PR DESCRIPTION
I'm interested in getting this added to the underlying jmeter docker image, so that https://github.com/egaillardon/jmeter-plugins can get updated to use it.

This allows supporting X11-forwarding/GUI mode:

![image](https://user-images.githubusercontent.com/64685/59620455-bc239280-90e1-11e9-933c-2e14a0034f1c.png)


# Running JMeter from Docker

## JMeter Docker Image

From: https://github.com/egaillardon/jmeter-plugins

## Install Quartz: 
  * Install the latest XQuartz X11 server (https://www.xquartz.org/) and run it
  * Activate the option ‘Allow connections from network clients’ in XQuartz settings
  * Quit & restart XQuartz (to activate the setting)

## Run Interactive UI:

```bash

# allow access from localhost
xhost + 127.0.0.1


docker pull egaillardon/jmeter-plugins
docker run -e DISPLAY=host.docker.internal:0 --interactive --tty --rm egaillardon/jmeter-plugins jmeter.sh
```
